### PR TITLE
Fixed linker error in `libc++/c++0x` environment.

### DIFF
--- a/socket.io-poco/include/SIOClientRegistry.h
+++ b/socket.io-poco/include/SIOClientRegistry.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <map>
+#include <string>
 
 class SIOClient;
 class SIOClientImpl;

--- a/socket.io-poco/include/SIOEventRegistry.h
+++ b/socket.io-poco/include/SIOEventRegistry.h
@@ -2,6 +2,7 @@
 
 #include "SIOEventTarget.h"
 #include <map>
+#include <string>
 
 #include "Poco/JSON/Parser.h"
 #include "Poco/BasicEvent.h"


### PR DESCRIPTION
Added `#import <string>` in `SIOClientRegistry.h` and `SIOEventRegistry.h`. ([Reference](http://llvm.org/bugs/show_bug.cgi?id=10521))
