### PR TITLE
[script]: modify cmake scripts to adapt to the low version g++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 2.8.9)
 
-
+set(CMAKE_CXX_STANDARD 11)
 execute_process(COMMAND "third_party/installDependancies.sh")
 add_subdirectory(src)


### PR DESCRIPTION
I found that cmake scripts can't build correctly in g++-4.8,and it work well after
specified CMAKE_CXX_STANDARD to 11.

Signed-off-by: sliver.chen <sliver.chen@rock-chips.com>